### PR TITLE
Use custom `TargetType` as the client return type

### DIFF
--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,8 +1,8 @@
 [package]
 org = "ballerinax"
 name = "sap"
-version = "1.0.1"
-distribution = "2201.9.0"
+version = "1.1.0"
+distribution = "2201.10.0"
 authors = ["Ballerina"]
 keywords = ["Business Management/ERP", "Cost/Paid"]
 export = ["sap"]
@@ -18,6 +18,6 @@ graalvmCompatible = true
 
 [[platform.java17.dependency]]
 groupId = "io.ballerina.lib.sap"
-artifactId = "sap-native-1.0.1-SNAPSHOT"
-version = "1.0.1-SNAPSHOT"
-path = "../native/build/libs/sap-native-1.0.1-SNAPSHOT.jar"
+artifactId = "sap-native-1.1.0-SNAPSHOT"
+version = "1.1.0-SNAPSHOT"
+path = "../native/build/libs/sap-native-1.1.0-SNAPSHOT.jar"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -5,12 +5,12 @@
 
 [ballerina]
 dependencies-toml-version = "2"
-distribution-version = "2201.9.0"
+distribution-version = "2201.10.0"
 
 [[package]]
 org = "ballerina"
 name = "auth"
-version = "2.11.0"
+version = "2.12.0"
 dependencies = [
 	{org = "ballerina", name = "crypto"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -50,7 +50,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "file"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -61,7 +61,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.11.2"
+version = "2.12.0"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "cache"},
@@ -93,7 +93,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "io"
-version = "1.6.0"
+version = "1.6.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.value"}
@@ -110,10 +110,11 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "jwt"
-version = "2.11.0"
+version = "2.13.0"
 dependencies = [
 	{org = "ballerina", name = "cache"},
 	{org = "ballerina", name = "crypto"},
+	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.int"},
 	{org = "ballerina", name = "lang.string"},
@@ -210,7 +211,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "log"
-version = "2.9.0"
+version = "2.10.0"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -221,11 +222,12 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "mime"
-version = "2.9.0"
+version = "2.10.0"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
-	{org = "ballerina", name = "lang.int"}
+	{org = "ballerina", name = "lang.int"},
+	{org = "ballerina", name = "log"}
 ]
 modules = [
 	{org = "ballerina", packageName = "mime", moduleName = "mime"}
@@ -234,7 +236,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "oauth2"
-version = "2.11.0"
+version = "2.12.0"
 dependencies = [
 	{org = "ballerina", name = "cache"},
 	{org = "ballerina", name = "crypto"},
@@ -247,7 +249,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "observe"
-version = "1.2.3"
+version = "1.3.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -315,7 +317,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "sap"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "jballerina.java"},

--- a/ballerina/sap_http_client.bal
+++ b/ballerina/sap_http_client.bal
@@ -17,6 +17,9 @@ import ballerina/http;
 import ballerina/jballerina.java;
 import ballerina/mime;
 
+# The `sap` client return type for the HTTP client actions.
+public type TargetType http:Response|anydata;
+
 # The `sap` client provides the capability for initiating contact with a remote HTTP service provided by any SAP products. The API it
 # provides includes the functions for the standard HTTP methods.
 public client isolated class Client {
@@ -50,7 +53,7 @@ public client isolated class Client {
     # + return - The response or the payload (if the `targetType` is configured) or an `sap:ClientError` if failed to
     # establish the communication with the upstream server or a data binding failure
     isolated resource function post [http:PathParamType... path](http:RequestMessage message, map<string|string[]>? headers = (), string?
-            mediaType = (), http:TargetType targetType = <>, *http:QueryParams params) returns targetType|ClientError = @java:Method {
+            mediaType = (), typedesc<TargetType> targetType = <>, *http:QueryParams params) returns targetType|ClientError = @java:Method {
         'class: "io.ballerina.lib.sap.ClientAction",
         name: "postResource"
     } external;
@@ -65,18 +68,18 @@ public client isolated class Client {
     # + return - The response or the payload (if the `targetType` is configured) or an `sap:ClientError` if failed to
     # establish the communication with the upstream server or a data binding failure
     remote isolated function post(string path, http:RequestMessage message, map<string|string[]>? headers = (),
-            string? mediaType = (), http:TargetType targetType = <>)
+            string? mediaType = (), typedesc<TargetType> targetType = <>)
             returns targetType|ClientError = @java:Method {
         'class: "io.ballerina.lib.sap.ClientAction"
     } external;
 
-    private isolated function processPost(string path, http:RequestMessage message, http:TargetType targetType,
-            string? mediaType, map<string|string[]>? headers) returns http:Response|anydata|ClientError {
+    private isolated function processPost(string path, http:RequestMessage message, typedesc<TargetType> targetType,
+            string? mediaType, map<string|string[]>? headers) returns TargetType|ClientError {
         map<string|string[]> headersModified = headers ?: {};
         string csrfToken = check self.fetchCSRFTokenForModifyingRequest();
         headersModified[SAP_CSRF_HEADER] = csrfToken;
         headersModified[ACCEPT_HEADER] = mime:APPLICATION_JSON;
-        http:Response|anydata|ClientError response = self.httpClient->post(path, message, headersModified, mediaType, targetType);
+        TargetType|ClientError response = self.httpClient->post(path, message, headersModified, mediaType, targetType);
         if isCSRFTokenFailure(response) {
             csrfToken = check self.fetchCSRFTokenForModifyingRequest(true);
             headersModified[SAP_CSRF_HEADER] = csrfToken;
@@ -96,7 +99,7 @@ public client isolated class Client {
     # + return - The response or the payload (if the `targetType` is configured) or an `sap:ClientError` if failed to
     # establish the communication with the upstream server or a data binding failure
     isolated resource function put [http:PathParamType... path](http:RequestMessage message, map<string|string[]>? headers = (), string?
-            mediaType = (), http:TargetType targetType = <>, *http:QueryParams params) returns targetType|ClientError = @java:Method {
+            mediaType = (), typedesc<TargetType> targetType = <>, *http:QueryParams params) returns targetType|ClientError = @java:Method {
         'class: "io.ballerina.lib.sap.ClientAction",
         name: "putResource"
     } external;
@@ -111,18 +114,18 @@ public client isolated class Client {
     # + return - The response or the payload (if the `targetType` is configured) or an `sap:ClientError` if failed to
     # establish the communication with the upstream server or a data binding failure
     remote isolated function put(string path, http:RequestMessage message, map<string|string[]>? headers = (),
-            string? mediaType = (), http:TargetType targetType = <>)
+            string? mediaType = (), typedesc<TargetType> targetType = <>)
             returns targetType|ClientError = @java:Method {
         'class: "io.ballerina.lib.sap.ClientAction"
     } external;
 
-    private isolated function processPut(string path, http:RequestMessage message, http:TargetType targetType,
-            string? mediaType, map<string|string[]>? headers) returns http:Response|anydata|ClientError {
+    private isolated function processPut(string path, http:RequestMessage message, typedesc<TargetType> targetType,
+            string? mediaType, map<string|string[]>? headers) returns TargetType|ClientError {
         map<string|string[]> headersModified = headers ?: {};
         string csrfToken = check self.fetchCSRFTokenForModifyingRequest();
         headersModified[SAP_CSRF_HEADER] = csrfToken;
         headersModified[ACCEPT_HEADER] = mime:APPLICATION_JSON;
-        http:Response|anydata|ClientError response = self.httpClient->put(path, message, headersModified, mediaType, targetType);
+        TargetType|ClientError response = self.httpClient->put(path, message, headersModified, mediaType, targetType);
         if isCSRFTokenFailure(response) {
             csrfToken = check self.fetchCSRFTokenForModifyingRequest(true);
             headersModified[SAP_CSRF_HEADER] = csrfToken;
@@ -143,7 +146,7 @@ public client isolated class Client {
     # + return - The response or the payload (if the `targetType` is configured) or an `sap:ClientError` if failed to
     # establish the communication with the upstream server or a data binding failure
     isolated resource function patch [http:PathParamType... path](http:RequestMessage message, map<string|string[]>? headers = (),
-            string? mediaType = (), http:TargetType targetType = <>, *http:QueryParams params) returns targetType|ClientError = @java:Method {
+            string? mediaType = (), typedesc<TargetType> targetType = <>, *http:QueryParams params) returns targetType|ClientError = @java:Method {
         'class: "io.ballerina.lib.sap.ClientAction",
         name: "patchResource"
     } external;
@@ -158,18 +161,18 @@ public client isolated class Client {
     # + return - The response or the payload (if the `targetType` is configured) or an `sap:ClientError` if failed to
     # establish the communication with the upstream server or a data binding failure
     remote isolated function patch(string path, http:RequestMessage message, map<string|string[]>? headers = (),
-            string? mediaType = (), http:TargetType targetType = <>)
+            string? mediaType = (), typedesc<TargetType> targetType = <>)
             returns targetType|ClientError = @java:Method {
         'class: "io.ballerina.lib.sap.ClientAction"
     } external;
 
-    private isolated function processPatch(string path, http:RequestMessage message, http:TargetType targetType,
-            string? mediaType, map<string|string[]>? headers) returns http:Response|anydata|ClientError {
+    private isolated function processPatch(string path, http:RequestMessage message, typedesc<TargetType> targetType,
+            string? mediaType, map<string|string[]>? headers) returns TargetType|ClientError {
         map<string|string[]> headersModified = headers ?: {};
         string csrfToken = check self.fetchCSRFTokenForModifyingRequest();
         headersModified[SAP_CSRF_HEADER] = csrfToken;
         headersModified[ACCEPT_HEADER] = mime:APPLICATION_JSON;
-        http:Response|anydata|ClientError response = self.httpClient->patch(path, message, headersModified, mediaType, targetType);
+        TargetType|ClientError response = self.httpClient->patch(path, message, headersModified, mediaType, targetType);
         if isCSRFTokenFailure(response) {
             csrfToken = check self.fetchCSRFTokenForModifyingRequest(true);
             headersModified[SAP_CSRF_HEADER] = csrfToken;
@@ -190,7 +193,7 @@ public client isolated class Client {
     # + return - The response or the payload (if the `targetType` is configured) or an `sap:ClientError` if failed to
     # establish the communication with the upstream server or a data binding failure
     isolated resource function delete [http:PathParamType... path](http:RequestMessage message = (), map<string|string[]>? headers = (),
-            string? mediaType = (), http:TargetType targetType = <>, *http:QueryParams params) returns targetType|ClientError = @java:Method {
+            string? mediaType = (), typedesc<TargetType> targetType = <>, *http:QueryParams params) returns targetType|ClientError = @java:Method {
         'class: "io.ballerina.lib.sap.ClientAction",
         name: "deleteResource"
     } external;
@@ -205,18 +208,18 @@ public client isolated class Client {
     # + return - The response or the payload (if the `targetType` is configured) or an `sap:ClientError` if failed to
     # establish the communication with the upstream server or a data binding failure
     remote isolated function delete(string path, http:RequestMessage message = (),
-            map<string|string[]>? headers = (), string? mediaType = (), http:TargetType targetType = <>)
+            map<string|string[]>? headers = (), string? mediaType = (), typedesc<TargetType> targetType = <>)
             returns targetType|ClientError = @java:Method {
         'class: "io.ballerina.lib.sap.ClientAction"
     } external;
 
-    private isolated function processDelete(string path, http:RequestMessage message, http:TargetType targetType,
-            string? mediaType, map<string|string[]>? headers) returns http:Response|anydata|ClientError {
+    private isolated function processDelete(string path, http:RequestMessage message, typedesc<TargetType> targetType,
+            string? mediaType, map<string|string[]>? headers) returns TargetType|ClientError {
         map<string|string[]> headersModified = headers ?: {};
         string csrfToken = check self.fetchCSRFTokenForModifyingRequest();
         headersModified[SAP_CSRF_HEADER] = csrfToken;
         headersModified[ACCEPT_HEADER] = mime:APPLICATION_JSON;
-        http:Response|anydata|ClientError response = self.httpClient->delete(path, message, headersModified, mediaType, targetType);
+        TargetType|ClientError response = self.httpClient->delete(path, message, headersModified, mediaType, targetType);
         if isCSRFTokenFailure(response) {
             csrfToken = check self.fetchCSRFTokenForModifyingRequest(true);
             headersModified[SAP_CSRF_HEADER] = csrfToken;
@@ -255,7 +258,7 @@ public client isolated class Client {
     # + params - The query parameters
     # + return - The response or the payload (if the `targetType` is configured) or an `sap:ClientError` if failed to
     # establish the communication with the upstream server or a data binding failure
-    isolated resource function get [http:PathParamType... path](map<string|string[]>? headers = (), http:TargetType targetType = <>,
+    isolated resource function get [http:PathParamType... path](map<string|string[]>? headers = (), typedesc<TargetType> targetType = <>,
             *http:QueryParams params) returns targetType|ClientError = @java:Method {
         'class: "io.ballerina.lib.sap.ClientAction",
         name: "getResource"
@@ -268,13 +271,13 @@ public client isolated class Client {
     # + targetType - HTTP response or `anydata`, which is expected to be returned after data binding
     # + return - The response or the payload (if the `targetType` is configured) or an `sap:ClientError` if failed to
     # establish the communication with the upstream server or a data binding failure
-    remote isolated function get(string path, map<string|string[]>? headers = (), http:TargetType targetType = <>)
+    remote isolated function get(string path, map<string|string[]>? headers = (), typedesc<TargetType> targetType = <>)
             returns targetType|ClientError = @java:Method {
         'class: "io.ballerina.lib.sap.ClientAction"
     } external;
 
-    private isolated function processGet(string path, map<string|string[]>? headers, http:TargetType targetType)
-            returns http:Response|anydata|error {
+    private isolated function processGet(string path, map<string|string[]>? headers, typedesc<TargetType> targetType)
+            returns TargetType|error {
         map<string|string[]> headersModified = headers ?: {};
         headersModified[ACCEPT_HEADER] = mime:APPLICATION_JSON;
         return self.httpClient->get(path, headersModified, targetType);
@@ -288,7 +291,7 @@ public client isolated class Client {
     # + params - The query parameters
     # + return - The response or the payload (if the `targetType` is configured) or an `sap:ClientError` if failed to
     # establish the communication with the upstream server or a data binding failure
-    isolated resource function options [http:PathParamType... path](map<string|string[]>? headers = (), http:TargetType targetType = <>,
+    isolated resource function options [http:PathParamType... path](map<string|string[]>? headers = (), typedesc<TargetType> targetType = <>,
             *http:QueryParams params) returns targetType|ClientError = @java:Method {
         'class: "io.ballerina.lib.sap.ClientAction",
         name: "optionsResource"
@@ -301,13 +304,13 @@ public client isolated class Client {
     # + targetType - HTTP response or `anydata`, which is expected to be returned after data binding
     # + return - The response or the payload (if the `targetType` is configured) or an `sap:ClientError` if failed to
     # establish the communication with the upstream server or a data binding failure
-    remote isolated function options(string path, map<string|string[]>? headers = (), http:TargetType targetType = <>)
+    remote isolated function options(string path, map<string|string[]>? headers = (), typedesc<TargetType> targetType = <>)
             returns targetType|ClientError = @java:Method {
         'class: "io.ballerina.lib.sap.ClientAction"
     } external;
 
-    private isolated function processOptions(string path, map<string|string[]>? headers, http:TargetType targetType)
-            returns http:Response|anydata|ClientError {
+    private isolated function processOptions(string path, map<string|string[]>? headers, typedesc<TargetType> targetType)
+            returns TargetType|ClientError {
         map<string|string[]> headersModified = headers ?: {};
         headersModified[ACCEPT_HEADER] = mime:APPLICATION_JSON;
         return self.httpClient->options(path, headersModified, targetType);
@@ -336,7 +339,7 @@ public client isolated class Client {
     }
 }
 
-isolated function isCSRFTokenFailure(http:Response|anydata|ClientError response) returns boolean {
+isolated function isCSRFTokenFailure(TargetType|ClientError response) returns boolean {
     if response is http:Response {
         if response.statusCode == http:STATUS_FORBIDDEN {
             string|http:HeaderNotFoundError header = response.getHeader(SAP_CSRF_HEADER);

--- a/build-config/resources/Ballerina.toml
+++ b/build-config/resources/Ballerina.toml
@@ -2,7 +2,7 @@
 org = "ballerinax"
 name = "sap"
 version = "@toml.version@"
-distribution = "2201.9.0"
+distribution = "2201.10.0"
 authors = ["Ballerina"]
 keywords = ["Business Management/ERP", "Cost/Paid"]
 export = ["sap"]

--- a/examples/pending-order-reminder/Ballerina.toml
+++ b/examples/pending-order-reminder/Ballerina.toml
@@ -10,5 +10,5 @@ observabilityIncluded = true
 [[dependency]]
 org = "ballerinax"
 name = "sap"
-version = "1.0.1"
+version = "1.1.0"
 repository = "local"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 org.gradle.caching=true
 group=io.ballerina.lib
-version=1.0.1-SNAPSHOT
+version=1.1.0-SNAPSHOT
 
 checkstylePluginVersion=10.12.0
 spotbugsPluginVersion=5.0.14
@@ -11,4 +11,4 @@ ballerinaGradlePluginVersion=2.2.0
 testngVersion=7.6.1
 eclipseLsp4jVersion=0.12.0
 
-ballerinaLangVersion=2201.9.0
+ballerinaLangVersion=2201.10.0


### PR DESCRIPTION
## Purpose

Defined a target type for the client return types which is `http:Response|anydata`, this will make sure the SAP client is not breaking with any change done to the `http:TargetType`, and limits the return type to `http:Response` and `anydata`.

With update 10, the `http:TargetType` has been change to `http:Response|anydata|stream<http:SseEvent, error?>`. This change is done to support Server-Sent Events with the HTTP client. Currently the Server-Sent Events are not fully supported(there is initial support to map single `text/event-stream` media type to the stream) in the OpenAPI client generation. So, with this change, the SAP connectors will not support Server-Sent Event binding. If this support is required, we have to change this target type to `http:Response|anydata|stream<http:SseEvent, error?>`.

Fixes: https://github.com/ballerina-platform/ballerina-library/issues/6905

## Examples

N/A

## Checklist

- [ ] ~Linked to an issue~
- [ ] ~Updated the specification~
- [ ] ~Updated the changelog~
- [ ] ~Added tests~
- [ ] ~Checked native-image compatibility~
