### PR TITLE
Fix CSRF token refresh failure

### DIFF
--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -2,7 +2,7 @@
 org = "ballerinax"
 name = "sap"
 version = "1.3.0"
-distribution = "2201.11.0-20241218-101200-109f6cc7"
+distribution = "2201.13.0"
 authors = ["Ballerina"]
 keywords = ["Business Management/ERP", "Cost/Paid"]
 repository = "https://github.com/ballerina-platform/module-ballerinax-sap"

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerinax"
 name = "sap"
-version = "1.2.0"
+version = "1.3.0"
 distribution = "2201.11.0-20241218-101200-109f6cc7"
 authors = ["Ballerina"]
 keywords = ["Business Management/ERP", "Cost/Paid"]
@@ -17,6 +17,6 @@ graalvmCompatible = true
 
 [[platform.java21.dependency]]
 groupId = "io.ballerina.lib.sap"
-artifactId = "sap-native-1.2.0"
-version = "1.2.0"
-path = "../native/build/libs/sap-native-1.2.0.jar"
+artifactId = "sap-native-1.3.0-SNAPSHOT"
+version = "1.3.0-SNAPSHOT"
+path = "../native/build/libs/sap-native-1.3.0-SNAPSHOT.jar"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -5,12 +5,12 @@
 
 [ballerina]
 dependencies-toml-version = "2"
-distribution-version = "2201.11.0"
+distribution-version = "2201.13.0"
 
 [[package]]
 org = "ballerina"
 name = "auth"
-version = "2.13.0"
+version = "2.14.0"
 dependencies = [
 	{org = "ballerina", name = "crypto"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -22,7 +22,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "cache"
-version = "3.9.0"
+version = "3.10.0"
 dependencies = [
 	{org = "ballerina", name = "constraint"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -33,7 +33,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "constraint"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -41,7 +41,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "crypto"
-version = "2.8.0"
+version = "2.10.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "time"}
@@ -50,7 +50,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "data.jsondata"
-version = "1.0.0"
+version = "1.1.3"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.object"}
@@ -59,7 +59,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "file"
-version = "1.11.0"
+version = "1.12.0"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -70,7 +70,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.13.3"
+version = "2.15.4"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "cache"},
@@ -103,7 +103,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "io"
-version = "1.7.0"
+version = "1.8.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.value"}
@@ -120,7 +120,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "jwt"
-version = "2.14.0"
+version = "2.15.1"
 dependencies = [
 	{org = "ballerina", name = "cache"},
 	{org = "ballerina", name = "crypto"},
@@ -221,7 +221,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "log"
-version = "2.11.0"
+version = "2.16.1"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -232,7 +232,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "mime"
-version = "2.11.0"
+version = "2.12.1"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -246,7 +246,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "oauth2"
-version = "2.13.0"
+version = "2.15.0"
 dependencies = [
 	{org = "ballerina", name = "cache"},
 	{org = "ballerina", name = "crypto"},
@@ -259,7 +259,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "observe"
-version = "1.4.0"
+version = "1.7.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -267,7 +267,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "os"
-version = "1.9.0"
+version = "1.10.1"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"}
@@ -276,10 +276,11 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "task"
-version = "2.6.0"
+version = "2.11.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
-	{org = "ballerina", name = "time"}
+	{org = "ballerina", name = "time"},
+	{org = "ballerina", name = "uuid"}
 ]
 
 [[package]]
@@ -299,7 +300,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "time"
-version = "2.6.0"
+version = "2.8.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -307,9 +308,20 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "url"
-version = "2.5.0"
+version = "2.6.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
+]
+
+[[package]]
+org = "ballerina"
+name = "uuid"
+version = "1.10.0"
+dependencies = [
+	{org = "ballerina", name = "crypto"},
+	{org = "ballerina", name = "jballerina.java"},
+	{org = "ballerina", name = "lang.int"},
+	{org = "ballerina", name = "time"}
 ]
 
 [[package]]
@@ -327,7 +339,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "sap"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "jballerina.java"},

--- a/ballerina/modules/mock/server.bal
+++ b/ballerina/modules/mock/server.bal
@@ -19,6 +19,8 @@ service /API_SALES_ORDER_SRV on new http:Listener(9093) {
 
     int headCount = 0;
     int postCount = 0;
+    int jsonPostCount = 0;
+    int recordPostCount = 0;
 
     resource function head .() returns http:Response {
         http:Response res = new;
@@ -60,6 +62,34 @@ service /API_SALES_ORDER_SRV on new http:Listener(9093) {
         res.setPayload("Sales Order Updated");
         return res;
 
+    }
+
+    resource function post A_RecordOrder(http:Request req) returns http:Response {
+        http:Response res = new;
+        if self.recordPostCount == 0 {
+            res.statusCode = 403;
+            res.addHeader("X-CSRF-TOKEN", "Required");
+            res.setPayload({message: "CSRF token validation failed"});
+        } else {
+            res.statusCode = 200;
+            res.setPayload({SalesOrder: "12345", SalesOrderType: "OR", SoldToParty: "17100001"});
+        }
+        self.recordPostCount = self.recordPostCount + 1;
+        return res;
+    }
+
+    resource function post A_JsonOrder(http:Request req) returns http:Response {
+        http:Response res = new;
+        if self.jsonPostCount == 0 {
+            res.statusCode = 403;
+            res.addHeader("X-CSRF-TOKEN", "Required");
+            res.setPayload({message: "CSRF token validation failed"});
+        } else {
+            res.statusCode = 200;
+            res.setPayload({orderId: "12345", status: "Created"});
+        }
+        self.jsonPostCount = self.jsonPostCount + 1;
+        return res;
     }
 
     resource function post A_SalesOrder(http:Request req) returns http:Response {

--- a/ballerina/sap_http_client.bal
+++ b/ballerina/sap_http_client.bal
@@ -129,7 +129,7 @@ public client isolated class Client {
         if isCSRFTokenFailure(response) {
             csrfToken = check self.fetchCSRFTokenForModifyingRequest(true);
             headersModified[SAP_CSRF_HEADER] = csrfToken;
-            return self.httpClient->post(path, message, headersModified, mediaType, targetType);
+            return self.httpClient->put(path, message, headersModified, mediaType, targetType);
         }
         return response;
 
@@ -176,7 +176,7 @@ public client isolated class Client {
         if isCSRFTokenFailure(response) {
             csrfToken = check self.fetchCSRFTokenForModifyingRequest(true);
             headersModified[SAP_CSRF_HEADER] = csrfToken;
-            return self.httpClient->post(path, message, headersModified, mediaType, targetType);
+            return self.httpClient->patch(path, message, headersModified, mediaType, targetType);
         }
         return response;
 
@@ -223,7 +223,7 @@ public client isolated class Client {
         if isCSRFTokenFailure(response) {
             csrfToken = check self.fetchCSRFTokenForModifyingRequest(true);
             headersModified[SAP_CSRF_HEADER] = csrfToken;
-            return self.httpClient->post(path, message, headersModified, mediaType, targetType);
+            return self.httpClient->delete(path, message, headersModified, mediaType, targetType);
         }
         return response;
 
@@ -344,6 +344,16 @@ isolated function isCSRFTokenFailure(TargetType|ClientError response) returns bo
         if response.statusCode == http:STATUS_FORBIDDEN {
             string|http:HeaderNotFoundError header = response.getHeader(SAP_CSRF_HEADER);
             if header is string && header.equalsIgnoreCaseAscii(SAP_CSRF_TOKEN_FAILURE_HEADER_VALUE) {
+                return true;
+            }
+        }
+    } else if response is http:ClientRequestError {
+        var detail = response.detail();
+        if detail.statusCode == http:STATUS_FORBIDDEN {
+            map<string[]> headers = detail.headers;
+            string[]? csrfHeader = headers[SAP_CSRF_HEADER] ?: headers[SAP_CSRF_HEADER.toLowerAscii()];
+            if csrfHeader is string[] && csrfHeader.length() > 0 &&
+                    csrfHeader[0].equalsIgnoreCaseAscii(SAP_CSRF_TOKEN_FAILURE_HEADER_VALUE) {
                 return true;
             }
         }

--- a/ballerina/tests/test.bal
+++ b/ballerina/tests/test.bal
@@ -46,6 +46,25 @@ function testTokenRefreshAfterExpiry() returns error? {
 @test:Config {
     dependsOn: [testTokenRefreshAfterExpiry]
 }
+function testTokenRefreshWithJsonTargetType() returns error? {
+    json response = check sapClient->post("/A_JsonOrder", "testPayload");
+    test:assertEquals(response, {orderId: "12345", status: "Created"});
+}
+
+@test:Config {
+    dependsOn: [testTokenRefreshWithJsonTargetType]
+}
+function testTokenRefreshWithRecordTargetType() returns error? {
+    record {|string SalesOrder; string SalesOrderType; string SoldToParty;|} response =
+        check sapClient->post("/A_RecordOrder", "testPayload");
+    test:assertEquals(response.SalesOrder, "12345");
+    test:assertEquals(response.SalesOrderType, "OR");
+    test:assertEquals(response.SoldToParty, "17100001");
+}
+
+@test:Config {
+    dependsOn: [testTokenRefreshWithRecordTargetType]
+}
 function testPostRemote() returns error? {
     http:Response response = check sapClient->/A_SalesOrder.post("testPayload");
     test:assertEquals(response.statusCode, 200, "Status code should be 200");

--- a/build-config/resources/Ballerina.toml
+++ b/build-config/resources/Ballerina.toml
@@ -2,7 +2,7 @@
 org = "ballerinax"
 name = "sap"
 version = "@toml.version@"
-distribution = "2201.11.0-20241218-101200-109f6cc7"
+distribution = "2201.13"
 authors = ["Ballerina"]
 keywords = ["Business Management/ERP", "Cost/Paid"]
 repository = "https://github.com/ballerina-platform/module-ballerinax-sap"

--- a/changelog.md
+++ b/changelog.md
@@ -9,7 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-### Changed
+- Depends on 2201.13.0 distribution
+
+### Fixed
+- [Fix Wrong HTTP method on retry for CSRF token failure](https://github.com/ballerina-platform/ballerina-library/issues/8640)
+- [Fix CSRF token refresh fails for request with databinding](https://github.com/ballerina-platform/ballerina-library/issues/8641)
 
 ## [1.2.0] - 03/03/2025
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 org.gradle.caching=true
 group=io.ballerina.lib
-version=1.2.1-SNAPSHOT
+version=1.3.0-SNAPSHOT
 
 checkstylePluginVersion=10.12.0
 spotbugsPluginVersion=6.0.18
@@ -11,4 +11,4 @@ ballerinaGradlePluginVersion=2.3.0
 testngVersion=7.6.1
 eclipseLsp4jVersion=0.12.0
 
-ballerinaLangVersion=2201.11.0
+ballerinaLangVersion=2201.13.0


### PR DESCRIPTION
## Purpose

Fixes: https://github.com/ballerina-platform/ballerina-library/issues/8640
Fixes: https://github.com/ballerina-platform/ballerina-library/issues/8641

The current Update 11 Docker image lacks the latest HTTP changes. Despite having sticky=true enabled, the build resolves the latest patch version of the HTTP library which introduces a Netty dependency mismatch. Updating the distribution ensures compatibility and prevents unrelated build failures

## Examples

## Checklist

- [x] Linked to an issue
- [x] Updated the specification
- [x] Updated the changelog
- [x] Added tests
- [x] Checked native-image compatibility


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new POST request handling with CSRF protection support.

* **Bug Fixes**
  * Fixed CSRF token refresh to use correct HTTP methods instead of reverting to POST.
  * Enhanced CSRF token failure detection to properly handle client request errors.

* **Dependencies**
  * Updated package version to 1.3.0 with upgraded distribution to 2201.13.0.
  * Updated multiple core packages including HTTP, authentication, and cryptography components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->